### PR TITLE
Fix preferPermissionPolicy option for permissions with "deny" value

### DIFF
--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1811,11 +1811,18 @@ describe('Policy checks for conditional policies', () => {
 });
 
 describe('Policy checks with preferPermissionPolicy config', () => {
-  const policies = [
+  const allowReadAndCreatepolicies = [
     // allow read for all resources
     ['role:default/all_resource_reader', 'catalog-entity', 'read', 'allow'],
     ['role:default/all_resource_reader', 'catalog-entity', 'create', 'allow'],
   ];
+
+  const allowCreateButDenyReadpolicies = [
+    // deny read for all resources
+    ['role:default/all_resource_reader', 'catalog-entity', 'read', 'deny'],
+    ['role:default/all_resource_reader', 'catalog-entity', 'create', 'allow'],
+  ];
+
   const groupPolicies = [
     ['user:default/mike', 'role:default/all_resource_reader'],
     ['user:default/mike', 'role:default/owned_resource_reader'],
@@ -1839,13 +1846,13 @@ describe('Policy checks with preferPermissionPolicy config', () => {
     },
   ];
 
-  it('should allow create when preferPermissionPolicy is true (permission policy first)', async () => {
+  it('should allow "catalog read operation" when preferPermissionPolicy is true (permission policy first) and read policy has "allow" value', async () => {
     const config = newConfig(undefined, undefined, undefined, true);
     const adapter = await newAdapter(config);
     const enfDelegate = await newEnforcerDelegate(
       adapter,
       config,
-      policies,
+      allowReadAndCreatepolicies,
       groupPolicies,
     );
     const policy = await newPermissionPolicy(config, enfDelegate);
@@ -1866,13 +1873,40 @@ describe('Policy checks with preferPermissionPolicy config', () => {
     expect(decision).toStrictEqual({ result: AuthorizeResult.ALLOW });
   });
 
-  it('should NOT allow create when preferPermissionPolicy is false by default (conditional policy first)', async () => {
-    const config = newConfig();
-    const adapter = await newAdapter(newConfig());
+  it('should deny "catalog read operation" when preferPermissionPolicy is true (permission policy first) and read policy has "deny" value', async () => {
+    const config = newConfig(undefined, undefined, undefined, true);
+    const adapter = await newAdapter(config);
     const enfDelegate = await newEnforcerDelegate(
       adapter,
       config,
-      policies,
+      allowCreateButDenyReadpolicies,
+      groupPolicies,
+    );
+    const policy = await newPermissionPolicy(config, enfDelegate);
+
+    // Mock conditionalStorage to return a conditional ALLOW for owned-reader
+    (
+      conditionalStorageMock.filterConditions as jest.Mock
+    ).mockResolvedValueOnce(conditionalPolicy);
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/mike', ['user:default/mike']), // user is owner
+    );
+    expect(decision).toStrictEqual({ result: AuthorizeResult.DENY });
+  });
+
+  it('should NOT allow read when preferPermissionPolicy is false by default (conditional policy first)', async () => {
+    const config = newConfig();
+    const adapter = await newAdapter(config);
+    const enfDelegate = await newEnforcerDelegate(
+      adapter,
+      config,
+      allowReadAndCreatepolicies,
       groupPolicies,
     );
     const policy = await newPermissionPolicy(config, enfDelegate);

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.test.ts
@@ -1811,15 +1811,19 @@ describe('Policy checks for conditional policies', () => {
 });
 
 describe('Policy checks with preferPermissionPolicy config', () => {
-  const allowReadAndCreatepolicies = [
+  const allowReadAndCreatePolicies = [
     // allow read for all resources
     ['role:default/all_resource_reader', 'catalog-entity', 'read', 'allow'],
     ['role:default/all_resource_reader', 'catalog-entity', 'create', 'allow'],
   ];
 
-  const allowCreateButDenyReadpolicies = [
+  const allowCreateButDenyReadPolicies = [
     // deny read for all resources
     ['role:default/all_resource_reader', 'catalog-entity', 'read', 'deny'],
+    ['role:default/all_resource_reader', 'catalog-entity', 'create', 'allow'],
+  ];
+
+  const allowOnlyCreateAndNoneReadPolicies = [
     ['role:default/all_resource_reader', 'catalog-entity', 'create', 'allow'],
   ];
 
@@ -1852,7 +1856,7 @@ describe('Policy checks with preferPermissionPolicy config', () => {
     const enfDelegate = await newEnforcerDelegate(
       adapter,
       config,
-      allowReadAndCreatepolicies,
+      allowReadAndCreatePolicies,
       groupPolicies,
     );
     const policy = await newPermissionPolicy(config, enfDelegate);
@@ -1879,7 +1883,7 @@ describe('Policy checks with preferPermissionPolicy config', () => {
     const enfDelegate = await newEnforcerDelegate(
       adapter,
       config,
-      allowCreateButDenyReadpolicies,
+      allowCreateButDenyReadPolicies,
       groupPolicies,
     );
     const policy = await newPermissionPolicy(config, enfDelegate);
@@ -1900,13 +1904,55 @@ describe('Policy checks with preferPermissionPolicy config', () => {
     expect(decision).toStrictEqual({ result: AuthorizeResult.DENY });
   });
 
+  it('should return conditional result for "catalog read operation" when preferPermissionPolicy is true (permission policy first) and there is no read policy value', async () => {
+    const config = newConfig(undefined, undefined, undefined, true);
+    const adapter = await newAdapter(config);
+    const enfDelegate = await newEnforcerDelegate(
+      adapter,
+      config,
+      allowOnlyCreateAndNoneReadPolicies,
+      groupPolicies,
+    );
+    const policy = await newPermissionPolicy(config, enfDelegate);
+
+    // Mock conditionalStorage to return a conditional ALLOW for owned-reader
+    (
+      conditionalStorageMock.filterConditions as jest.Mock
+    ).mockResolvedValueOnce(conditionalPolicy);
+
+    const decision = await policy.handle(
+      newPolicyQueryWithResourcePermission(
+        'catalog.entity.read',
+        'catalog-entity',
+        'read',
+      ),
+      newPolicyQueryUser('user:default/mike', ['user:default/mike']), // user is owner
+    );
+    expect(decision).toStrictEqual({
+      pluginId: 'catalog',
+      resourceType: 'catalog-entity',
+      result: AuthorizeResult.CONDITIONAL,
+      conditions: {
+        anyOf: [
+          {
+            rule: 'IS_ENTITY_OWNER',
+            resourceType: 'catalog-entity',
+            params: {
+              claims: ['user:default/mike'],
+            },
+          },
+        ],
+      },
+    });
+  });
+
   it('should NOT allow read when preferPermissionPolicy is false by default (conditional policy first)', async () => {
     const config = newConfig();
     const adapter = await newAdapter(config);
     const enfDelegate = await newEnforcerDelegate(
       adapter,
       config,
-      allowReadAndCreatepolicies,
+      allowReadAndCreatePolicies,
       groupPolicies,
     );
     const policy = await newPermissionPolicy(config, enfDelegate);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PreferPermissionPolicy should respect permission policies with a "deny" value. Currently, it works only for "allow" values. A conditional policy should be returned only when there are no defined policies (with either "allow" or "deny" values).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
